### PR TITLE
Update xencelabs.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,31 @@ Use as an input for your flake and import the module into your NixOS system conf
 ```
 services.xencelabs.enable = true;
 ```
+
+### Noob Guide
+
+This is how I was able to get it working on my setup, I may not fully understand how to use a flake.nix, so hopefully someone can correct my usage if possible.
+
+1. Download the `xencelabs.nix` file to your `/etc/nixos` folder.
+2. Add the following to the top of your `configuration.nix`:
+```
+{ config, pkgs, ... }:
+
+let
+  ...
+  xencelabsPackage = import /etc/nixos/xencelabs.nix { 
+    inherit (pkgs) pkgs fetchzip; 
+  };
+  ...
+in
+```
+3. Then add the package to your package list and the udev rule:
+```
+services.udev.packages = [ xencelabsPackage ];
+environment.systemPackages = with pkgs; [
+...
+  xencelabsPackage
+...
+];
+```
+4. `nixos-rebuild switch` to install it (reboot recommended for the udev rules)!

--- a/xencelabs.nix
+++ b/xencelabs.nix
@@ -1,20 +1,20 @@
-{ stdenv, fetchzip, wrapQtAppsHook, lib, libusb, xorg, libsForQt5, libglvnd, glibc, qtbase, ... }:
+{ pkgs, fetchzip, ... }:
 let
   driversZipFile = fetchzip {
-    url = "https://www.xencelabs.com/support/file/id/11/type/1";
+    url = "https://www.xencelabs.com/support/file/id/61/type/1";
     extension = "zip";
-    sha256 = "sha256-lHlE0ZRRJ0A7caPJOeapqnNqJV4h8Tl5JkmHuMYcS8Q=";
+    sha256 = "sha256-FSxR7SekHqvvRXkNMcSpGumw8TTnRWGPP/N/rya1VOk=";
     stripRoot = true;
   };
 in
 
-stdenv.mkDerivation rec {
+pkgs.stdenv.mkDerivation rec {
   name = "xencelabs";
-  version = "1.2.1-11";
-  src = "${driversZipFile}/${name}-${version}.x86_64.tar.gz";
+  version = "1.3.4-26";
+  src = "${driversZipFile}/${name}-${version}.tar.gz";
 
-  buildInputs = [ qtbase ];
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  buildInputs = [ pkgs.libsForQt5.qt5.qtbase ];
+  nativeBuildInputs = [ pkgs.libsForQt5.qt5.wrapQtAppsHook ];
 
   installPhase = ''
     # Copy udev rule
@@ -37,8 +37,8 @@ stdenv.mkDerivation rec {
   '';
   preFixup = let
     # we prepare our library path in the let clause to avoid it become part of the input of mkDerivation
-    libPath = lib.makeLibraryPath [
-      libusb                       # libusb-1.0.so.0
+    libPath = pkgs.lib.makeLibraryPath (with pkgs; [
+      xorg.libXrandr               # libXrandr.so.2
       xorg.libX11                  # libX11.so.6
       xorg.libXtst                 # libXtst.so.6
       libsForQt5.qt5.qtx11extras   # libQt5X11Extras.so.5
@@ -46,7 +46,8 @@ stdenv.mkDerivation rec {
       libsForQt5.qt5.qtbase        # libQt5Widgets.so.5 libQt5Gui.so.5 libQt5Xml.so.5 libQt5Network.so.5 libQt5Core.so.5
       libglvnd                     # libGL.so.1
       stdenv.cc.cc.lib             # libstdc++.so.6
-    ];
+      libusb1                      # libusb-1.0.so.0
+    ]);
   in ''
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \

--- a/xencelabs.nix
+++ b/xencelabs.nix
@@ -1,17 +1,17 @@
 { pkgs, fetchzip, ... }:
 let
   driversZipFile = fetchzip {
-    url = "https://www.xencelabs.com/support/file/id/61/type/1";
+    url = "https://www.xencelabs.com/support/file/id/11/type/1";
     extension = "zip";
-    sha256 = "sha256-FSxR7SekHqvvRXkNMcSpGumw8TTnRWGPP/N/rya1VOk=";
+    sha256 = "sha256-lHlE0ZRRJ0A7caPJOeapqnNqJV4h8Tl5JkmHuMYcS8Q=";
     stripRoot = true;
   };
 in
 
 pkgs.stdenv.mkDerivation rec {
   name = "xencelabs";
-  version = "1.3.4-26";
-  src = "${driversZipFile}/${name}-${version}.tar.gz";
+  version = "1.2.1-11";
+  src = "${driversZipFile}/${name}-${version}.x86_64.tar.gz";
 
   buildInputs = [ pkgs.libsForQt5.qt5.qtbase ];
   nativeBuildInputs = [ pkgs.libsForQt5.qt5.wrapQtAppsHook ];
@@ -57,7 +57,10 @@ pkgs.stdenv.mkDerivation rec {
     # fix the path in the desktop file
     substituteInPlace \
       $out/share/applications/xencelabs.desktop \
-      --replace /usr/lib/xencelabs/xencelabs.sh $out/bin/xencelabs \
       --replace /usr/share/icons $out/usr/share/icons
+
+    substituteInPlace \
+      $out/share/applications/xencelabs.desktop \
+      --replace "/usr/lib/xencelabs/xencelabs.sh" $out/bin/xencelabs \
   '';
 }


### PR DESCRIPTION
This pull request updates the `xencelabs.nix` file to support the stateVersion 24.11 and the most recent driver release from Xencelabs 1.3.4-26.
I also added some notes on how to install it (because I didn't fully understand it, someone else might find it useful), but please correct it if I didn't do it right!
Thank you for creating this repository! I'm going to keep drawing in Krita on Linux because of it!